### PR TITLE
Fix page generation error with multiple agents

### DIFF
--- a/app/Http/Controllers/ConversationsController.php
+++ b/app/Http/Controllers/ConversationsController.php
@@ -248,7 +248,7 @@ class ConversationsController extends Controller
             }
             // Show replying first.
             usort($viewers, function($a, $b) {
-                return $a['replying'] < $b['replying'];
+                return $a['replying'] <=> $b['replying'];
             });
         }
 


### PR DESCRIPTION
When multiple agents were viewing an email, the following error was seen:

usort(): Returning bool from comparison function is deprecated, return
    an integer less than, equal to, or greater than zero at
    /www/html/app/Http/Controllers/ConversationsController.php:252

Opted for spaceship operator, I was not able to verify that the code is
operating as intended, only that it resolved the generated error.